### PR TITLE
Update blast.py

### DIFF
--- a/CRISPR_comparison_toolkit/cctkpkg/blast.py
+++ b/CRISPR_comparison_toolkit/cctkpkg/blast.py
@@ -614,7 +614,7 @@ def main(args):
         
     if args.regex_pattern:
         assembly_names = [a for a in subprocess.run(
-            "blastdbcmd -db {} -entry all -outfmt '\%a' | grep -o{} '{}' | \
+            "blastdbcmd -db {} -entry all -outfmt '%a' | grep -o{} '{}' | \
             sort | uniq".format(
                 args.blast_db_path,
                 args.regex_type,


### PR DESCRIPTION
There's a \ on line 617 that adds a literal \ in front of the patterns for genome name. When I print all_assemblies_dict.items(), I see: Found \AML2_cluster_001_consensus, <cctkpkg.file_handling.AssemblyCRISPRs object at 0x2b9da84c61f0> Running cctk blast gives me:
Traceback (most recent call last):
  File "/N/slate/cganote/apis/CRISPR_comparison_toolkit/CRISPR_comparison_toolkit/cctk_blast/../cctk", line 168, in <module>
    main()
  File "/N/slate/cganote/apis/CRISPR_comparison_toolkit/CRISPR_comparison_toolkit/cctk_blast/../cctk", line 157, in main
    blast.main(args)
  File "/N/slate/cganote/apis/CRISPR_comparison_toolkit/CRISPR_comparison_toolkit/cctkpkg/blast.py", line 664, in main
    assembly = all_assemblies_dict[array.genome]
KeyError: 'AML2_cluster_001_consensus'

I think you won't need the \ and it runs ok when I removed it.